### PR TITLE
Moving Averages

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ If `false` disables simple graphic smoothing.
 
 ### smoothingFunction
 
-Possible values are `movingAverage`, `weightedMovingAverage`, or `none`, defaults to `none`
+Possible values are `movingAverage`, `weightedMovingAverage`, `cumulative` or `none`, defaults to `none`
 
 ### smoothingArgs
 

--- a/README.md
+++ b/README.md
@@ -111,13 +111,10 @@ Note that the percentage symbol triggers % formatting.
 
 If `false` disables simple graphic smoothing.
 
-### smoothingFunction
+### transform
 
-Possible values are `movingAverage`, `weightedMovingAverage`, `cumulative` or `none`, defaults to `none`
-
-### smoothingArgs
-
-Size of the sliding window for moving averages, defaults to `7`
+Possible values are `movingAverage`, `weightedMovingAverage`, `cumulative` or `none`, defaults to `none`.
+You can set the size of the sliding window for moving averages in parentheses. For example `movingAverage(3)`, defaults to `7`
 
 ### data
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ to MAX_INT
 
 Grouping by date. One of either `hour`, `day`, `week`, or `month` which groups all the data by the start of
 the time period, using your first date column as the key. Simply sums all the other property fields.
-Defaults to no grouping.
+Defaults to group by day.
 
 ### groupByFunction
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ If `false` disables simple graphic smoothing.
 
 ### smoothingFunction
 
-Possible values are `movingAverage` or `none`, defaults to `none`
+Possible values are `movingAverage`, `weightedMovingAverage`, or `none`, defaults to `none`
 
 ### smoothingArgs
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ The name of the data property that holds the Y-axis value. Must be a number. Def
 ### valueProperties
 
 An array of data properties for the Y-axis values. Will generate multi-series data with a legend.
-If you specify multiple properties here, the `function` attribute will be applied to each series first,
+If you specify multiple properties here, the `reduction` attribute will be applied to each series first,
 and then to the collection of resulting values. Rolling up the roll ups as it were. If you want to hide
-the primary metric, set the `function` attribute to `none`
+the primary metric, set the `reduction` attribute to `none`
 
 ### limit
 
@@ -96,7 +96,7 @@ Defaults to group by day.
 Sets the reduction function to apply when aggregating groupbed values. The default value
 is `sum`. Possible values are: `first`, `last`, `sum`, `average`, `min`, `max`, and `count`.
 
-### function
+### reduction
 
 Sets the reduction function to apply the data values to create the primary metric. The default value
 is `average`. Possible values are: `first`, `last`, `sum`, `average`, `min`, `max`, and `count`, 'cummulative'
@@ -179,7 +179,7 @@ The layout of the tile is automatically configured by the type of data you pass 
 
 * If you set the `data` attribute to exactly two values, the first value will be used as the primary metric, and the second value will be considered the previous value for that metric. A percent change will automatically be shown in this case. If you want to display the previous value, rather than the change, set the `absolute` attribute to `true`.
 
-* If you set the `data` attribute to three or more values, a primary metric will be displayed and a sparkline of the values will be generated. By default the sum of the array will be the primary metric, but this can be controlled via the `function` attribute. If you only want to consider a subset of the values, set the `limit` attribute to truncate the list to the last `limit` elements. For example, the following URL returns 365 days of data in JSON format, but we only care about the last 7 days, and the "applied" property.
+* If you set the `data` attribute to three or more values, a primary metric will be displayed and a sparkline of the values will be generated. By default the sum of the array will be the primary metric, but this can be controlled via the `reduction` attribute. If you only want to consider a subset of the values, set the `limit` attribute to truncate the list to the last `limit` elements. For example, the following URL returns 365 days of data in JSON format, but we only care about the last 7 days, and the "applied" property.
   
   ```html
   <ui-stats-number name="CM Applications (7 days)" 
@@ -221,7 +221,7 @@ _&lt;integer&gt;_
 
 Number of elements (from the end of the array) to use from `data`
 
-#### function
+#### reduction
 
 _&lt;string&gt;_
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ is `sum`. Possible values are: `first`, `last`, `sum`, `average`, `min`, `max`, 
 ### function
 
 Sets the reduction function to apply the data values to create the primary metric. The default value
-is `average`. Possible values are: `first`, `last`, `sum`, `average`, `min`, `max`, and `count`, `none`. The value
-of `none` hides the metric area, just showing the graph.
+is `average`. Possible values are: `first`, `last`, `sum`, `average`, `min`, `max`, and `count`, 'cummulative'
+and `none`. The value of `none` hides the metric area, just showing the graph.
 
 ### units
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,15 @@ Note that the percentage symbol triggers % formatting.
 
 ### smooth
 
-If `false` disables data smoothing.
+If `false` disables simple graphic smoothing.
+
+### smoothingFunction
+
+Possible values are `movingAverage` or `none`, defaults to `none`
+
+### smoothingArgs
+
+Size of the sliding window for moving averages, defaults to `7`
 
 ### data
 

--- a/demo.html
+++ b/demo.html
@@ -18,8 +18,19 @@
     
     <h1>Timelines</h1>
 
-    <ui-stats-timeline label="Mean CM Acceptance Percentage" units="%" groupBy="week" groupByFunction="average"
-      src="https://query.glgroup.com/councilApplicant/getStats.mustache" limit="6" trendline="true"
+
+    <ui-stats-timeline label="Raw Data with Trendline" units="%" groupBy="day" smooth="false"
+      src="https://query.glgroup.com/councilApplicant/getStats.mustache" limit="30" trendline="true"
+      valueProperty="accept_rate">
+    </ui-stats-timeline>
+
+    <ui-stats-timeline label="Raw Data with Trendline (smoothed)" units="%" groupBy="day" smooth="true"
+      src="https://query.glgroup.com/councilApplicant/getStats.mustache" limit="30" trendline="true"
+      valueProperty="accept_rate">
+    </ui-stats-timeline>
+
+    <ui-stats-timeline label="7 day Moving Average" units="%" groupBy="day" smoothingFunction="movingAverage"
+      src="https://query.glgroup.com/councilApplicant/getStats.mustache" limit="30" smoothingArgs="7"
       valueProperty="accept_rate">
     </ui-stats-timeline>
         

--- a/demo.html
+++ b/demo.html
@@ -29,7 +29,12 @@
       valueProperty="accept_rate">
     </ui-stats-timeline>
 
-    <ui-stats-timeline label="7 day Moving Average" units="%" groupBy="day" smoothingFunction="movingAverage"
+    <ui-stats-timeline label="7 day Simple Moving Average" units="%" groupBy="day" smoothingFunction="movingAverage"
+      src="https://query.glgroup.com/councilApplicant/getStats.mustache" limit="30" smoothingArgs="7"
+      valueProperty="accept_rate">
+    </ui-stats-timeline>
+
+    <ui-stats-timeline label="7 day Weighted Moving Average" units="%" groupBy="day" smoothingFunction="weightedMovingAverage"
       src="https://query.glgroup.com/councilApplicant/getStats.mustache" limit="30" smoothingArgs="7"
       valueProperty="accept_rate">
     </ui-stats-timeline>

--- a/demo.html
+++ b/demo.html
@@ -38,6 +38,11 @@
       src="https://query.glgroup.com/councilApplicant/getStats.mustache" limit="30" smoothingArgs="7"
       valueProperty="accept_rate">
     </ui-stats-timeline>
+    
+    <ui-stats-timeline label="Cumulative" groupBy="week" smoothingFunction="cumulative" type="area" function="sum"
+      src="https://query.glgroup.com/councilApplicant/getStats.mustache" limit="30"
+      valueProperty="paid">
+    </ui-stats-timeline>
         
     <ui-stats-timeline label="Mean CM Acceptance Percentage" units="%" groupBy="week" groupByFunction="average"
       src="https://query.glgroup.com/councilApplicant/getStats.mustache"

--- a/demo.html
+++ b/demo.html
@@ -29,17 +29,22 @@
       valueProperty="accept_rate">
     </ui-stats-timeline>
 
-    <ui-stats-timeline label="7 day Simple Moving Average" units="%" groupBy="day" smoothingFunction="movingAverage"
-      src="https://query.glgroup.com/councilApplicant/getStats.mustache" limit="30" smoothingArgs="7"
+    <ui-stats-timeline label="7 day Simple Moving Average" units="%" groupBy="day" transform="movingAverage"
+      src="https://query.glgroup.com/councilApplicant/getStats.mustache" limit="30"
       valueProperty="accept_rate">
     </ui-stats-timeline>
 
-    <ui-stats-timeline label="7 day Weighted Moving Average" units="%" groupBy="day" smoothingFunction="weightedMovingAverage"
-      src="https://query.glgroup.com/councilApplicant/getStats.mustache" limit="30" smoothingArgs="7"
+    <ui-stats-timeline label="3 day Simple Moving Average" units="%" groupBy="day" transform="movingAverage(3)"
+      src="https://query.glgroup.com/councilApplicant/getStats.mustache" limit="30"
+      valueProperty="accept_rate">
+    </ui-stats-timeline>
+
+    <ui-stats-timeline label="7 day Weighted Moving Average" units="%" groupBy="day" transform="weightedMovingAverage"
+      src="https://query.glgroup.com/councilApplicant/getStats.mustache" limit="30"
       valueProperty="accept_rate">
     </ui-stats-timeline>
     
-    <ui-stats-timeline label="Cumulative" groupBy="week" smoothingFunction="cumulative" type="area" reduction="sum"
+    <ui-stats-timeline label="Cumulative" groupBy="week" transform="cumulative" type="area" reduction="sum"
       src="https://query.glgroup.com/councilApplicant/getStats.mustache" limit="30"
       valueProperty="paid">
     </ui-stats-timeline>

--- a/demo.html
+++ b/demo.html
@@ -39,7 +39,7 @@
       valueProperty="accept_rate">
     </ui-stats-timeline>
     
-    <ui-stats-timeline label="Cumulative" groupBy="week" smoothingFunction="cumulative" type="area" function="sum"
+    <ui-stats-timeline label="Cumulative" groupBy="week" smoothingFunction="cumulative" type="area" reduction="sum"
       src="https://query.glgroup.com/councilApplicant/getStats.mustache" limit="30"
       valueProperty="paid">
     </ui-stats-timeline>
@@ -49,7 +49,7 @@
       valueProperty="accept_rate">
     </ui-stats-timeline>
     
-    <ui-stats-timeline label="Peak CM Acceptance Percentage" units="%" groupBy="week" function="max" smooth="false"
+    <ui-stats-timeline label="Peak CM Acceptance Percentage" units="%" groupBy="week" reduction="max" smooth="false"
       src="https://query.glgroup.com/councilApplicant/getStats.mustache" type="column"
       valueProperty="accept_rate" groupByFunction="average">
     </ui-stats-timeline>
@@ -59,13 +59,13 @@
       valueProperty="paid">
     </ui-stats-timeline>
 
-    <ui-stats-timeline label="Multi-Series Data: Accepted and Paid"  limit="365" function="sum" groupBy="week"
+    <ui-stats-timeline label="Multi-Series Data: Accepted and Paid"  limit="365" reduction="sum" groupBy="week"
       src="https://query.glgroup.com/councilApplicant/getStats.mustache" type="area"
       valueProperties="['paid', 'accepted']">
     </ui-stats-timeline>
     
     <ui-stats-timeline label="Mean Response time" units="ms" limit="30" groupByFunction="sum"
-      src="https://query.glgroup.com/councilApplicant/getStats.mustache" type="area" function="none"
+      src="https://query.glgroup.com/councilApplicant/getStats.mustache" type="area" reduction="none"
       valueProperty="paid">
     </ui-stats-timeline>
 
@@ -86,22 +86,22 @@
 
     <ui-stats-timeline label="Static Object Array"
       data="[ {'date':'2015-01-01', 'count':3}, {'date':'2015-02-01','count':11}, {'date':'2015-03-01','count':2}, {'date':'2015-04-01','count':5} ]"
-      valueProperty="count" function="last">
+      valueProperty="count" reduction="last">
     </ui-stats-timeline>
 
     <ui-stats-timeline label="Static Object Array NumStrings"
       data="[ {'date':'2015-01-01', 'count':'3'}, {'date':'2015-02-01','count':'11'}, {'date':'2015-03-01','count':'2'}, {'date':'2015-04-01','count':'5'} ]"
-      valueProperty="count" function="last">
+      valueProperty="count" reduction="last">
     </ui-stats-timeline>
 
     <ui-stats-timeline label="Static Object Array NumStrings (Week)" groupBy="week"
       data="[ {'date':'2015-01-01', 'count':'3'}, {'date':'2015-02-01','count':'11'}, {'date':'2015-03-01','count':'2'}, {'date':'2015-04-01','count':'5'} ]"
-      valueProperty="count" function="last">
+      valueProperty="count" reduction="last">
     </ui-stats-timeline>
     
     <ui-stats-timeline label="Static Object Array Defaults"
       data="[ {'date':'2015-01-01', 'value':3}, {'date':'2015-02-01','value':11}, {'date':'2015-03-01','value':2}, {'date':'2015-04-01','value':5} ]"
-      function="last">
+      reduction="last">
     </ui-stats-timeline>
     
     <h1>Number Tiles</h1>
@@ -121,10 +121,10 @@
     <ui-stats-number name="History - Smooth" data="[10, 20, 15, 30, 45, 12]" smooth="true">
     </ui-stats-number>
 
-    <ui-stats-number name="History - Last" data="[10, 20, 15, 30, 45, 12]" smooth="true" function="last">
+    <ui-stats-number name="History - Last" data="[10, 20, 15, 30, 45, 12]" smooth="true" reduction="last">
     </ui-stats-number>
 
-    <ui-stats-number name="History - Avg" data="[10, 20, 15, 30, 45, 12]" smooth="true" function="average">
+    <ui-stats-number name="History - Avg" data="[10, 20, 15, 30, 45, 12]" smooth="true" reduction="average">
     </ui-stats-number>
 
     <ui-stats-number name="Epiquery Results" src="https://query.glgroup.com/councilApplicant/getStats.mustache"

--- a/src/ui-stats-number.html
+++ b/src/ui-stats-number.html
@@ -1,4 +1,5 @@
-<polymer-element name="ui-stats-number" attributes="value data name units src property limit function smooth absolute method">
+<polymer-element name="ui-stats-number" attributes="value data name units src property limit
+ function reduction smooth absolute method">
   <link rel="import" href="../google-chart/google-chart.html">
 
   <template>

--- a/src/ui-stats-number.litcoffee
+++ b/src/ui-stats-number.litcoffee
@@ -13,6 +13,12 @@ along with associated secondary metrics, such as a change indicator or sparkline
       valueChanged: ->
         @data = [ @value ]
 
+deprecated properties
+
+      functionChanged: ->
+        @reduction = @function
+
+
       dataChanged: ->
         
 Data is trunctated to the last `limit` elements of the array
@@ -22,10 +28,10 @@ Data is trunctated to the last `limit` elements of the array
 The primary value is the result of applying the reduction `function`, unless overriden. By default we sum the values
 if we have more than 2 values, otherwise we show the last value
 
-        if not @function?
-          @function = "sum" if data.length > 2
-          @function = "last" if data.length <= 2
-        @primaryMetric = @reduce @function, data
+        if not @reduction?
+          @reduction = "sum" if data.length > 2
+          @reduction = "last" if data.length <= 2
+        @primaryMetric = @reduce @reduction, data
           
         console.log "NumberStat: #{@name}, #{data}"
         switch data.length
@@ -75,7 +81,7 @@ Splits numbers into whole and fractional parts so we can style them separately
 
 ## Helpers
 
-Reduction function, specified by the `@function` attribute
+Reduction function, specified by the `@reduction` attribute
 
       reduce: (operation, values) ->
         switch operation
@@ -108,7 +114,7 @@ Reduction function, specified by the `@function` attribute
         @value = null
         @change = null
         @primaryMetric = null
-        @function = null
+        @reduction = null
         @limit = 100
         @absolute = false
         @smooth = false

--- a/src/ui-stats-timeline.html
+++ b/src/ui-stats-timeline.html
@@ -1,4 +1,8 @@
-<polymer-element name="ui-stats-timeline" attributes="data src limit label groupBy groupByFunction function units dateProperty valueProperty datePattern smooth type valueProperties method trendline smoothingFunction smoothingWindow">
+<polymer-element name="ui-stats-timeline" attributes="data src limit label
+   groupBy groupByFunction reduction units dateProperty valueProperty datePattern
+   smooth type valueProperties method trendline smoothingFunction smoothingWindow
+   function
+   ">
   <link rel="import" href="../google-chart/google-chart.html">
 
   <template>
@@ -7,7 +11,7 @@
     <h2>{{label}}</h2>
     <div class="timeline">
 
-      <div class="data" hidden?="{{function == 'none'}}">
+      <div class="data" hidden?="{{reduction == 'none'}}">
         <span class="number" hidden?="{{loading}}">{{value}}{{units}}</span>
         <span class="loading" hidden?="{{!loading}}">Loading...</span>
       </div>

--- a/src/ui-stats-timeline.html
+++ b/src/ui-stats-timeline.html
@@ -1,6 +1,6 @@
 <polymer-element name="ui-stats-timeline" attributes="data src limit label
    groupBy groupByFunction reduction units dateProperty valueProperty datePattern
-   smooth type valueProperties method trendline smoothingFunction smoothingWindow
+   smooth type valueProperties method trendline transform
    function
    ">
   <link rel="import" href="../google-chart/google-chart.html">

--- a/src/ui-stats-timeline.html
+++ b/src/ui-stats-timeline.html
@@ -1,4 +1,4 @@
-<polymer-element name="ui-stats-timeline" attributes="data src limit label groupBy groupByFunction function units dateProperty valueProperty datePattern smooth type valueProperties method trendline">
+<polymer-element name="ui-stats-timeline" attributes="data src limit label groupBy groupByFunction function units dateProperty valueProperty datePattern smooth type valueProperties method trendline smoothingFunction smoothingWindow">
   <link rel="import" href="../google-chart/google-chart.html">
 
   <template>

--- a/src/ui-stats-timeline.litcoffee
+++ b/src/ui-stats-timeline.litcoffee
@@ -116,6 +116,8 @@
             _.last data
           when 'count'
             data.length
+          when 'cumulative'
+            @accumulate data
           when 'none'
             0
           else
@@ -129,7 +131,7 @@
           if @smoothingFunction in ['weightedMovingAverage', 'movingAverage']
             smoothedValues[propertyName] = @movingAverage values, @smoothingArgs
           else if @smoothingFunction is 'cumulative'
-            smoothedValues[propertyName] = @cumulativeValues values
+            smoothedValues[propertyName] = @accumulate values
           else
             smoothedValues[propertyName] = values
         rowIndex = 0
@@ -140,7 +142,7 @@
           rowIndex++
           result
       
-      cumulativeValues: (values) ->
+      accumulate: (values) ->
         results = []
         for value,index in values
           results.push _.sum values.slice(0,index)

--- a/src/ui-stats-timeline.litcoffee
+++ b/src/ui-stats-timeline.litcoffee
@@ -140,9 +140,17 @@
         window = []
         for value in values
           window.push value
-          if window.length > lookback
-            window.shift()
-          results.push _.sum(window) / window.length
+          window.shift() if window.length > lookback
+
+          if @smoothingFunction is 'weightedMovingAverage'
+            index = 0
+            results.push _.reduce window, (total, n) ->
+              index++
+              multiplier = index / _.sum [1..window.length]
+              total + n * multiplier
+            , 0
+          else
+            results.push _.sum(window) / window.length
         results
 
       dataChanged: ->

--- a/src/ui-stats-timeline.litcoffee
+++ b/src/ui-stats-timeline.litcoffee
@@ -126,7 +126,12 @@
         smoothedValues = {}
         for propertyName, propertyIndex in @valueProperties
           values = _.map rows, (row) -> row[propertyIndex + 1]
-          smoothedValues[propertyName] = @movingAverage values, @smoothingArgs
+          if @smoothingFunction in ['weightedMovingAverage', 'movingAverage']
+            smoothedValues[propertyName] = @movingAverage values, @smoothingArgs
+          else if @smoothingFunction is 'cumulative'
+            smoothedValues[propertyName] = @cumulativeValues values
+          else
+            smoothedValues[propertyName] = values
         rowIndex = 0
         _.map rows, (row) =>
           result = [ row[0] ]
@@ -134,7 +139,13 @@
             result.push smoothedValues[propertyName][rowIndex]
           rowIndex++
           result
-
+      
+      cumulativeValues: (values) ->
+        results = []
+        for value,index in values
+          results.push _.sum values.slice(0,index)
+        results
+        
       movingAverage: (values, lookback) ->
         results = []
         window = []

--- a/src/ui-stats-timeline.litcoffee
+++ b/src/ui-stats-timeline.litcoffee
@@ -14,6 +14,7 @@
         @valueProperty = 'value'
         @valueProperties = [ 'value' ]
         @function = 'average'
+        @groupBy = 'day'
         @groupByFunction = 'sum'
         @units = ''
         @limit = Number.MAX_VALUE

--- a/src/ui-stats-timeline.litcoffee
+++ b/src/ui-stats-timeline.litcoffee
@@ -131,7 +131,8 @@
         _.map rows, (row) =>
           result = [ row[0] ]
           for propertyName in @valueProperties
-            result.push smoothedValues[propertyName][rowIndex++]
+            result.push smoothedValues[propertyName][rowIndex]
+          rowIndex++
           result
 
       movingAverage: (values, lookback) ->

--- a/src/ui-stats-timeline.litcoffee
+++ b/src/ui-stats-timeline.litcoffee
@@ -13,7 +13,7 @@
         @dateProperty = 'date'
         @valueProperty = 'value'
         @valueProperties = [ 'value' ]
-        @function = 'average'
+        @reduction = 'average'
         @groupBy = 'day'
         @groupByFunction = 'sum'
         @units = ''
@@ -55,6 +55,8 @@
             baselineColor: '#aaa'
       valuePropertyChanged: ->
         @valueProperties = [ @valueProperty ]
+
+property handlers
         
       srcChanged: ->
         @loading = true
@@ -65,6 +67,13 @@
             console.log "Error loading data from #{@src}", err
           else
             @data = json
+
+deprecated properties
+
+      functionChanged: ->
+        @reduction = @function
+
+other stuff
       
       createDataFromJson: (json) ->
         @applyGrouping _.map json, (item) =>
@@ -91,8 +100,8 @@
         seriesValues = []
         for propertyName, index in @valueProperties
           values = _.map rows, (row) -> row[index + 1]
-          seriesValues.push @applyReductionFunction @function, values
-        value = @applyReductionFunction @function, seriesValues
+          seriesValues.push @applyReductionFunction @reduction, values
+        value = @applyReductionFunction @reduction, seriesValues
         @value = switch @units
           when '%'
             numeral(value * 100).format '0.0'


### PR DESCRIPTION
Option to apply moving averages to the data. If you have grouping enabled (by week for example) then the average is applied after the grouping.

This PR also sets the default grouping to “day”, which should have no effect for most everyone.
